### PR TITLE
Support for `boolOrStringWithOrientation` propType, for usage with carousel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8520,6 +8520,15 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "pre-push": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pre-push/-/pre-push-0.1.1.tgz",
+      "integrity": "sha1-Kip5gn0kOnbJEImJescH9F5xaqw=",
+      "dev": true,
+      "requires": {
+        "shelljs": "0.3.x"
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -9402,6 +9411,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
     },
     "shellwords": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
     "lrud": "^2.7.0"
   },
   "devDependencies": {
+    "@babel/cli": "^7.2.3",
+    "@babel/core": "^7.3.4",
+    "@babel/preset-env": "^7.3.4",
+    "@babel/preset-react": "^7.0.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^4.18.1",
@@ -44,10 +48,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "in-publish": "^2.0.0",
     "jest": "^24.1.0",
-    "@babel/cli": "^7.2.3",
-    "@babel/core": "^7.3.4",
-    "@babel/preset-env": "^7.3.4",
-    "@babel/preset-react": "^7.0.0"
+    "pre-push": "^0.1.1"
   },
   "dependencies": {
     "airbnb-prop-types": "^2.8.1",
@@ -59,6 +60,7 @@
     "react-dom": "^16.2.0",
     "rimraf": "^2.6.2"
   },
+  "pre-push": [ "lint", "test" ],
   "scripts": {
     "clean": "rimraf dist",
     "lint": "eslint src test",

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -1,4 +1,4 @@
-import { shape, func, string, bool, oneOf, element } from 'prop-types'
+import { shape, func, string, bool, oneOf, element, oneOfType } from 'prop-types'
 import { and } from 'airbnb-prop-types'
 
 const withOrientation = (props, propName) => {
@@ -7,7 +7,7 @@ const withOrientation = (props, propName) => {
   }
 }
 
-const boolOrString = oneOf([
+const boolOrString = oneOfType([
   bool,
   string
 ])

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -7,11 +7,17 @@ const withOrientation = (props, propName) => {
   }
 }
 
+const boolOrString = oneOf([
+  bool,
+  string
+])
+
 export default {
   string,
   element,
   bool,
   func,
+  boolOrString,
   orientation: oneOf([
     'vertical',
     'horizontal'
@@ -26,6 +32,10 @@ export default {
   ]),
   funcAndOrientation: and([
     func,
+    withOrientation
+  ]),
+  boolOrStringWithOrientation: and([
+    boolOrString,
     withOrientation
   ])
 }

--- a/src/with-navigation.js
+++ b/src/with-navigation.js
@@ -68,7 +68,7 @@ const withNavigation = (InnerComponent, { includeProps } = {}) => {
     orientation: PropTypes.orientation,
     vertical: PropTypes.bool,
     horizontal: PropTypes.bool,
-    carousel: PropTypes.boolAndOrientation,
+    carousel: PropTypes.boolOrStringWithOrientation,
     grid: PropTypes.boolAndOrientation,
     wrapping: PropTypes.boolAndOrientation,
     disabled: PropTypes.bool,

--- a/test/with-navigation.test.js
+++ b/test/with-navigation.test.js
@@ -292,4 +292,42 @@ describe('withNavigation', () => {
       foo: true
     })
   })
+
+  it('should register a `horizontal` item with a carousel of a string', () => {
+    const Navigable = withNavigation(Passthrough)
+    const navigation = { register: jest.fn(), unregister: () => {} }
+
+    shallow(
+      <Navigable
+        id='foo'
+        horizontal
+        carousel={'x'}
+      />,
+      { context: { navigation } }
+    )
+
+    expect(navigation.register).toHaveBeenCalledWith('foo', {
+      orientation: 'horizontal',
+      carousel: 'x'
+    })
+  })
+
+  it('should register a `horizontal` item with a carousel of a bool', () => {
+    const Navigable = withNavigation(Passthrough)
+    const navigation = { register: jest.fn(), unregister: () => {} }
+
+    shallow(
+      <Navigable
+        id='foo'
+        horizontal
+        carousel
+      />,
+      { context: { navigation } }
+    )
+
+    expect(navigation.register).toHaveBeenCalledWith('foo', {
+      orientation: 'horizontal',
+      carousel: true
+    })
+  })
 })


### PR DESCRIPTION
# Scenario
I'm attempting to fix warnings/errors we see all the time

We have legitimate use cases where a navigable item with a `carousel` prop needs to be a `string` - e.g

```js
// when you scroll the content grid, do movement via the `root-container_mask` DOM node
<ContentGrid carousel={'root-container'} />
```

The React LRUD prop types are **wildly out of date** - they expect the carousel to always be a bool (and be in the presence of an orientation)

I've added a new prop type that instead of 'a bool with an orientation' represents 'a bool OR a string, either with an orientation'

# Changelog

- added new prop type
- made the Navigable `carousel` prop use that new prop type
- added some tests